### PR TITLE
Feature/oauth 소셜로그인 로직 최초 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/service/runnersmap/component/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/service/runnersmap/component/OAuth2AuthSuccessHandler.java
@@ -68,7 +68,7 @@ public class OAuth2AuthSuccessHandler implements AuthenticationSuccessHandler {
           user.getLastPosition(),
           user.getProfileImageUrl());
 
-      // JSON 응답으로 반환 or 특정 페이지로 리디렉션하는 방법도 있음
+      // JSON 응답으로 반환(현재상태) // 특정 페이지로 리디렉션하는 방법도 있다고 함
       response.setContentType("application/json");
       response.setCharacterEncoding("UTF-8");
       response.getWriter()

--- a/src/main/java/com/service/runnersmap/component/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/service/runnersmap/component/OAuth2AuthSuccessHandler.java
@@ -1,0 +1,82 @@
+package com.service.runnersmap.component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.service.runnersmap.dto.LoginResponse;
+import com.service.runnersmap.entity.CustomOAuth2User;
+import com.service.runnersmap.entity.User;
+import com.service.runnersmap.exception.RunnersMapException;
+import com.service.runnersmap.repository.UserRepository;
+import com.service.runnersmap.service.CustomOAuth2UserService;
+import com.service.runnersmap.type.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2AuthSuccessHandler implements AuthenticationSuccessHandler {
+// OAuth2 인증이 된 후 호출되는 핸들러 => 사용자에게 JWT 토큰 발급 / 추가정보 입력 페이지로 리디렉션
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final UserRepository userRepository;
+  private final CustomOAuth2UserService customOAuth2UserService;
+
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+
+    // 인증완료된 사용자의 정보 가져오기
+    CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    // 이메일 추출
+    String email = oAuth2User.getEmail();
+
+    log.info("Google 로그인 성공, email: {}", email);
+
+    // DB에서 사용자 조회
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> {
+          log.warn("사용자가 존재하지 않습니다. email: {} ", email);
+          return new RunnersMapException(ErrorCode.NOT_FOUND_USER);
+        });
+
+    // 신규 사용자 - 추가 정보 입력 페이지로 리디렉션
+    if (customOAuth2UserService.isNewUser(user)) {
+      log.info("신규 사용자의 상세 정보를 얻기 위해 /complete-sign-up 페이지로 리디렉션.");
+      response.sendRedirect("/complete-sign-up?email=" + email);
+
+    } else {
+      // 기존 사용자 - JWT 토큰 발급
+      log.info("기존 사용자를 위한 JWT 토큰 발급");
+      String accessToken = jwtTokenProvider.generateAccessToken(email);
+      String refreshToken = jwtTokenProvider.generateRefreshToken(email);
+
+      LoginResponse loginResponse = new LoginResponse(
+          accessToken,
+          refreshToken,
+          user.getId(),
+          user.getNickname(),
+          user.getEmail(),
+          user.getGender(),
+          user.getLastPosition(),
+          user.getProfileImageUrl());
+
+      // JSON 응답으로 반환 or 특정 페이지로 리디렉션하는 방법도 있음
+      response.setContentType("application/json");
+      response.setCharacterEncoding("UTF-8");
+      response.getWriter()
+          .write(new ObjectMapper().writeValueAsString(loginResponse));
+      log.info("JWT 토큰 발급 완료");
+
+    }
+
+  }
+
+}

--- a/src/main/java/com/service/runnersmap/config/SecurityConfig.java
+++ b/src/main/java/com/service/runnersmap/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
 //  public UrlBasedCorsConfigurationSource corsConfigurationSource() {
 //    CorsConfiguration configuration = new CorsConfiguration();
 //    configuration.setAllowCredentials(false); // 인증 관련 설정
-//    configuration.addAllowedOriginPattern("http://3.37.126.40"); // 모든 도메인을 허용 (cors관련)
+//    configuration.addAllowedOriginPattern("http://");
 //    configuration.addAllowedHeader("*"); // 모든 헤더 허용
 //    configuration.addAllowedMethod("*"); // 모든 메서드 허용 (GET, POST, PUT, DELETE 등)
 //

--- a/src/main/java/com/service/runnersmap/config/SecurityConfig.java
+++ b/src/main/java/com/service/runnersmap/config/SecurityConfig.java
@@ -1,6 +1,10 @@
 package com.service.runnersmap.config;
 
 import com.service.runnersmap.component.JwtFilter;
+import com.service.runnersmap.component.OAuth2AuthSuccessHandler;
+import com.service.runnersmap.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,9 +17,14 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomOAuth2UserService customOAuth2UserService;
+  private final OAuth2AuthSuccessHandler oAuth2AuthSuccessHandler;
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -33,15 +42,35 @@ public class SecurityConfig {
             .requestMatchers(
                 "/api/user/sign-up",
                 "/api/user/login",
-                "/api/user/refresh"
-            ).permitAll()
+                "/api/user/refresh")
+            .permitAll()
             .anyRequest().authenticated()
+        )
+        .oauth2Login(oauth2 -> oauth2
+            .loginPage("/oauth2/authorization/google")
+            .userInfoEndpoint(userInfo -> userInfo
+                .userService(customOAuth2UserService)
+            )
+            .successHandler(oAuth2AuthSuccessHandler)
         )
         // 폼 로그인 기능을 비활성화
         .formLogin(form -> form.disable())
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // jwt 필터 추가
     return http.build();
   }
+
+//  @Bean
+//  public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+//    CorsConfiguration configuration = new CorsConfiguration();
+//    configuration.setAllowCredentials(false); // 인증 관련 설정
+//    configuration.addAllowedOriginPattern("http://3.37.126.40"); // 모든 도메인을 허용 (cors관련)
+//    configuration.addAllowedHeader("*"); // 모든 헤더 허용
+//    configuration.addAllowedMethod("*"); // 모든 메서드 허용 (GET, POST, PUT, DELETE 등)
+//
+//    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+//    source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 CORS 설정 적용
+//    return source;
+//  }
 
   @Bean
   public CorsFilter corsFilter() {

--- a/src/main/java/com/service/runnersmap/controller/UserController.java
+++ b/src/main/java/com/service/runnersmap/controller/UserController.java
@@ -1,12 +1,14 @@
 package com.service.runnersmap.controller;
 
 import com.service.runnersmap.dto.LoginResponse;
+import com.service.runnersmap.dto.UserDto;
 import com.service.runnersmap.dto.UserDto.AccountDeleteDto;
 import com.service.runnersmap.dto.UserDto.AccountInfoDto;
 import com.service.runnersmap.dto.UserDto.AccountUpdateDto;
 import com.service.runnersmap.dto.UserDto.LastPositionDto;
 import com.service.runnersmap.dto.UserDto.LoginDto;
 import com.service.runnersmap.dto.UserDto.SignUpDto;
+import com.service.runnersmap.service.CustomOAuth2UserService;
 import com.service.runnersmap.service.UserService;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -31,12 +33,23 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
 
   private final UserService userService;
+  private final CustomOAuth2UserService  customOAuth2UserService;
 
   // 회원가입 API
   @PostMapping("/sign-up")
   public ResponseEntity<Void> signUp(@RequestBody SignUpDto signUpDto) {
     userService.signUp(signUpDto);
     return ResponseEntity.status(HttpStatus.CREATED).build(); // 201 Created
+  }
+
+
+  // 소셜 로그인 첫 시도시, 추가 정보 입력
+  @PostMapping("/complete-sign-up")
+  public ResponseEntity<LoginResponse> completeSignUp(
+      @RequestParam String email,
+      @RequestBody @Valid UserDto.CompleteSignUpDto completeSignUpDto) {
+    LoginResponse loginResponse = customOAuth2UserService.completeSignUp(email,completeSignUpDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(loginResponse);
   }
 
 

--- a/src/main/java/com/service/runnersmap/dto/UserDto.java
+++ b/src/main/java/com/service/runnersmap/dto/UserDto.java
@@ -30,6 +30,19 @@ public class UserDto {
   @NoArgsConstructor
   @AllArgsConstructor
   @Builder
+  public static class CompleteSignUpDto {
+
+    @NotBlank(message = "닉네임을 입력해주세요")
+    private String nickname;  // 닉네임
+    @NotBlank(message = "성별을 입력해주세요.")
+    private String gender;    // 성별
+
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
   public static class LoginDto {
 
     @Email(message = "이메일 형식에 맞게 입력해주세요")

--- a/src/main/java/com/service/runnersmap/entity/AfterRunPicture.java
+++ b/src/main/java/com/service/runnersmap/entity/AfterRunPicture.java
@@ -38,6 +38,7 @@ public class AfterRunPicture {
   private String afterRunPictureUrl;
   private LocalDateTime createdAt;
 
+  @Builder.Default
   private Integer likeCount = 0;  // 좋아요 수, 기본값 0
 
   @Version

--- a/src/main/java/com/service/runnersmap/entity/CustomOAuth2User.java
+++ b/src/main/java/com/service/runnersmap/entity/CustomOAuth2User.java
@@ -5,15 +5,17 @@ import java.util.Collections;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @RequiredArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
 
   private final User user;
+  // OAuth2 인증 과정에서 제공된 사용자의 데이터 담긴 맵 (JSON 형식)
+  // 구글이 제공하는 사용자 데이터를 담고 있음.
   private final Map<String, Object> attributes;
 
+  // 사용자 속성 정보 반환
   @Override
   public Map<String, Object> getAttributes() {
     return attributes;
@@ -21,14 +23,19 @@ public class CustomOAuth2User implements OAuth2User {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    // 우리 서비스에서는 ROLE_USER를 사용하지 않기 때문에 권한 없이 반환
+    return Collections.emptyList();
   }
 
+  // 사용자 식별자 반환 (유일식별자로 이메일 반환)
+  // 인터페이스 구현을 위해 오버라이드 했으나 식별자가 이메일인 게 꺼림칙.
+  // id로 바꾸자니 반환형이 String이라 일단 email로.
   @Override
   public String getName() {
     return user.getEmail();
   }
 
+// 사실상 상단의 메서드와 같은 역할이지만 명확한 역할구분을 위해 따로 만듦
   public String getEmail() {
     return user.getEmail();
   }

--- a/src/main/java/com/service/runnersmap/entity/CustomOAuth2User.java
+++ b/src/main/java/com/service/runnersmap/entity/CustomOAuth2User.java
@@ -1,0 +1,35 @@
+package com.service.runnersmap.entity;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+  private final User user;
+  private final Map<String, Object> attributes;
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+  }
+
+  @Override
+  public String getName() {
+    return user.getEmail();
+  }
+
+  public String getEmail() {
+    return user.getEmail();
+  }
+}

--- a/src/main/java/com/service/runnersmap/entity/User.java
+++ b/src/main/java/com/service/runnersmap/entity/User.java
@@ -20,10 +20,10 @@ public class User {
   @Column(name = "email", nullable = false)
   private String email;
 
-  @Column(name = "password", nullable = false)
+  @Column(name = "password")
   private String password;
 
-  @Column(name = "nickname", nullable = false)
+  @Column(name = "nickname")
   private String nickname;
 
   @Column(name = "gender")
@@ -40,6 +40,5 @@ public class User {
 
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
-
 }
 

--- a/src/main/java/com/service/runnersmap/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/service/runnersmap/service/CustomOAuth2UserService.java
@@ -30,22 +30,30 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
+    // 사용자 정보 가져오기
     OAuth2User oAuth2User = super.loadUser(userRequest);
-
+    // 구글 로그인에서 이메일 정보 추출
     String email = oAuth2User.getAttribute("email");
 
+    // 이메일로 사용자 검색, 없으면 새 사용자 생성
     User user = userRepository.findByEmail(email)
         .orElseGet(() -> createNewUser(oAuth2User));
 
+    // 사용자 정보와 CustomOAuth2User 객체 반환
     return new CustomOAuth2User(user, oAuth2User.getAttributes());
-
   }
 
+
+  // 신규사용자인지 확인하는 메서드 (닉네임이나 성별이 null 이면 신규사용자)
   public boolean isNewUser(User user) {
     return user.getNickname() == null || user.getGender() == null;
   }
 
+
+  // 새 사용자 생성 메서드
   private User createNewUser(OAuth2User oAuth2User) {
+
+    // 사용자 데이터 추출
     String email = oAuth2User.getAttribute("email");
 
     User newUser = User.builder()
@@ -53,18 +61,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         .password("") // 소셜로그인은 비번 필요 없음
         .nickname(null) // 닉네임 나중에 설정
         .gender(null) // 성별 나중에 설정
+        .profileImageUrl("")
         .createdAt(LocalDateTime.now())
         .build();
 
     log.info("소셜 사용자 회원가입 : {}", email);
+    // 사용자 저장
     return userRepository.save(newUser);
   }
 
-  // 추가 정보 설정 & 토큰 발급
+  // 추가 정보 설정 & JWT 토큰 발급
   @Transactional
   public LoginResponse completeSignUp(String email, CompleteSignUpDto completeSignUpDto) {
+    // 이메일로 사용자 검색, 없으면 예외 발생
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+
+    // 닉네임 중복 확인
+    if (userRepository.findByNickname(completeSignUpDto.getNickname()).isPresent()) {
+      throw new RunnersMapException(ErrorCode.ALREADY_EXISTS_NICKNAME);
+    }
 
     // 닉네임, 성별 신규 설정
     user.setNickname(completeSignUpDto.getNickname());
@@ -72,7 +88,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     user.setUpdatedAt(LocalDateTime.now());
     userRepository.save(user);
 
-    // JWT 토큰 발급
+    // JWT 엑세스, 리프레시 토큰 발급
     String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());
     String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
 
@@ -80,10 +96,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         accessToken,
         refreshToken,
         user.getId(),
-        user.getEmail(),
         user.getNickname(),
+        user.getEmail(),
         user.getGender(),
-        "", // 마지막 위치
-        "" ); // 프사url
+        null, // 마지막 위치
+        ""); // 프사url
+
   }
 }

--- a/src/main/java/com/service/runnersmap/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/service/runnersmap/service/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.service.runnersmap.service;
+
+import com.service.runnersmap.component.JwtTokenProvider;
+import com.service.runnersmap.dto.LoginResponse;
+import com.service.runnersmap.dto.UserDto.CompleteSignUpDto;
+import com.service.runnersmap.entity.CustomOAuth2User;
+import com.service.runnersmap.entity.User;
+import com.service.runnersmap.exception.RunnersMapException;
+import com.service.runnersmap.repository.UserRepository;
+import com.service.runnersmap.type.ErrorCode;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+// OAuth2 사용자 정보 로드 & 해당 사용자가 DB에 없는 경우, 새 사용자 생성하는 서비스코드
+
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+
+    String email = oAuth2User.getAttribute("email");
+
+    User user = userRepository.findByEmail(email)
+        .orElseGet(() -> createNewUser(oAuth2User));
+
+    return new CustomOAuth2User(user, oAuth2User.getAttributes());
+
+  }
+
+  public boolean isNewUser(User user) {
+    return user.getNickname() == null || user.getGender() == null;
+  }
+
+  private User createNewUser(OAuth2User oAuth2User) {
+    String email = oAuth2User.getAttribute("email");
+
+    User newUser = User.builder()
+        .email(email)
+        .password("") // 소셜로그인은 비번 필요 없음
+        .nickname(null) // 닉네임 나중에 설정
+        .gender(null) // 성별 나중에 설정
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    log.info("소셜 사용자 회원가입 : {}", email);
+    return userRepository.save(newUser);
+  }
+
+  // 추가 정보 설정 & 토큰 발급
+  @Transactional
+  public LoginResponse completeSignUp(String email, CompleteSignUpDto completeSignUpDto) {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new RunnersMapException(ErrorCode.NOT_FOUND_USER));
+
+    // 닉네임, 성별 신규 설정
+    user.setNickname(completeSignUpDto.getNickname());
+    user.setGender(completeSignUpDto.getGender());
+    user.setUpdatedAt(LocalDateTime.now());
+    userRepository.save(user);
+
+    // JWT 토큰 발급
+    String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());
+    String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
+
+    return new LoginResponse(
+        accessToken,
+        refreshToken,
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getGender(),
+        "", // 마지막 위치
+        "" ); // 프사url
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. 신규로 소셜 로그인 시 닉네임, 성별을 작성하는 부분까지 넘어가는 건 로그로 확인 완료했습니다.  
2. 신규 사용자일 시, 로그인 후 닉네임과 성별을 설정할 수 있는 페이지로 리디렉션 되도록 했습니다. 
(수정페이지 엔드포인트 : api/user/complete-sign-up, 쿼리 : email)
3. 신규 사용자일 시, 닉네임 중복 확인 로직을 거쳐 닉네임을 설정할 수 있습니다.
4. 기존 사용자인 경우, 로그인 response와 동일합니다. 
5. 이해하기 좋게 주석을 추가했습니다.
6. 마지막 위치는 null, 프로필사진 url은 ""로 반환합니다. 기존의 로그인 응답에 맞게 통일한 것입니다.

**TO-BE**
- HTTPS 로 배포 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
